### PR TITLE
Remove reference to deprecated constants. 

### DIFF
--- a/jforms/apres-submit.gtw
+++ b/jforms/apres-submit.gtw
@@ -207,8 +207,8 @@ un autre nom, faites un setData.
 Exemple :
 <code php>
     $form->saveFile('photo');
-    $form->saveFile('photo', JELIX_APP_WWW_PATH.'images/photos/');
-    $form->saveFile('photo', JELIX_APP_WWW_PATH.'images/photos/', $id.'.png');
+    $form->saveFile('photo', jApp::wwwPath('images/photos/'));
+    $form->saveFile('photo', jApp::wwwPath('images/photos/', $id.'.png'));
     $form->saveFile('photo', '', $id.'.png');
 </code>
 
@@ -218,7 +218,7 @@ Exemple :
 
 <code php>
     $form->saveAllFiles();
-    $form->saveAllFiles(JELIX_APP_WWW_PATH.'images/photos/');
+    $form->saveAllFiles(jApp::wwwPath('images/photos/'));
 </code>
 
 

--- a/vues/vue-fichier-binaire.gtw
+++ b/vues/vue-fichier-binaire.gtw
@@ -35,7 +35,7 @@ contenu que vous générez vous-même.
 Pour renvoyer un fichier existant :
 
 <code php>
- $rep->fileName = JELIX_APP_VAR_PATH.'fichier_a_renvoyer.gif';
+ $rep->fileName = jApp::varPath('fichier_a_renvoyer.gif');
 </code>
 
 Et sinon, si vous générez vous-même, mettez le contenu dans une chaîne et mettez


### PR DESCRIPTION
Removes reference to deprecated constants in examples, such as JELIX_APP_WWW_PATH and JELIX_APP_VAR_PATH.

Should be ported to branches 1.4.x and 1.3.x ASAP, as it can be source of confusion

BTW: is there a way to use normal " ' " instead of " ’ " in code examples?
