### PR TITLE
jAuth : Broken link to reference jIAuthDriver

### DIFF
--- a/authentification/drivers.gtw
+++ b/authentification/drivers.gtw
@@ -57,7 +57,7 @@ champ du login, ou alors qu'il y ait une clé autoincrementée, et un champ
 
 C'est un driver plus universel que celui de Db, dans la mesure où vous devez lui
 fournir une classe, dans laquelle vous faîtes ce que vous voulez. Elle doit
-respecter [[refclass:auth/jIAuthDriverClass|l'interface jIAuthDriverClass]].
+respecter [[refclass:auth/jIAuthDriver|l'interface jIAuthDriver]].
 Cette classe doit être stockée dans le répertoire "classes" d'un de vos modules,
 comme n'importe quelle classe métier.
 


### PR DESCRIPTION
The name of the interface is jIAuthDriver and not jIAuthDriverClass (link and label corrected)
