### PR TITLE
Apostrophe devant une url

### DIFF
--- a/classes-utiles/jmailer.gtw
+++ b/classes-utiles/jmailer.gtw
@@ -167,5 +167,5 @@ $mail->Send();
 
 jMailer utilise comme base PHPMailer, si vous voulez avoir d'avantage de
 documentation, consultez
-l'[[http://phpmailer.worxware.com/index.php?pg=methods|aide en ligne de
+[[http://phpmailer.worxware.com/index.php?pg=methods|l'aide en ligne de
 PHPMailer]].


### PR DESCRIPTION
L'apostrophe devant le double crochet du wiki empêche le moteur d'afficher le lien correctement. Egalement présent en 1.4. Peut-être un bug lié au moteur du wiki?
