### PR TITLE
Rectification affichage des liens

### DIFF
--- a/bd/outils.gtw
+++ b/bd/outils.gtw
@@ -10,8 +10,7 @@ d'une table, etc. Elle s'accompagne des classes @@C@jDbtable@@ et
 Ces classes sont pour le moment assez expérimentales, et tous les drivers ne
 sont pas supportés.
 
-Vous pouvez récupérer un objet @@C@jDbSchema@@ en appelant la méthode @@M@schema
-()@@ d'un objet @@C@jDbConnection@@.
+Vous pouvez récupérer un objet @@C@jDbSchema@@ en appelant la méthode @@M@schema()@@ d'un objet @@C@jDbConnection@@.
 
 Voir la documentation de réference.
 


### PR DESCRIPTION
Le retour chariot dans une balise @@ a cassé la présentation des liens.
Bug présent dans les versions 1.3 1.4 1.5 et master
