### PR TITLE
Exemple erroné

### DIFF
--- a/creer-script-installation.gtw
+++ b/creer-script-installation.gtw
@@ -92,7 +92,7 @@ class newsModuleInstaller extends jInstallerModule {
     function install() {
     }
 
-    function preInstall() {
+    function postInstall() {
 
     }
 


### PR DESCRIPTION
Le code d'exemple contenait deux fois la même fonction, j'ai transformé un des preInstall en postInstall
