### PR TITLE
Update affichage.gtw

### DIFF
--- a/jforms/affichage.gtw
+++ b/jforms/affichage.gtw
@@ -355,7 +355,7 @@ paramètre, ici "legacy.htmllight" :
 
 Comme indiqué plus haut, ces plugins acceptent un cinquième paramètre, un
 tableau, contenant des options pour le générateur. Ces options dépendent du
-générateur utilisé (//errorDecorator// et //method// par exemple pour 'html').
+générateur utilisé (//errorDecorator//, //method// et //plugins// par exemple pour 'html').
 
 Remarque : si vous souhaitez passer la même option dans tous vos formulaires,
 créez le générateur de votre choix en dérivant un générateur existant et


### PR DESCRIPTION
pour le générateur html fourni il y a 3 paramètres et non 2.
c'est important car si on veut utiliser ses propres formwidget il me semble que c'est le seul endroit où on puisse l'indiquer